### PR TITLE
PAAS-379: new root password is not added anymore to env vars

### DIFF
--- a/utils/set-jahia-root-password.yml
+++ b/utils/set-jahia-root-password.yml
@@ -10,11 +10,8 @@ globals:
   new_password: ${settings.rootpwd}
 
 onInstall:
-  - api [cp,proc]: env.control.AddContainerEnvVars
-    vars: {"SUPER_USER_PASSWORD": "${globals.new_password}"}
-
   - cmd [proc]: |-
-        echo $SUPER_USER_PASSWORD > $DATA_PATH/digital-factory-data/root.pwd
+        echo ${globals.new_password} > $DATA_PATH/digital-factory-data/root.pwd
         chown tomcat:tomcat $DATA_PATH/digital-factory-data/root.pwd
 
 settings:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-379

Short description:
new root password is not added anymore to env vars