### PR TITLE
PAAS-379: the root password update package now expects a base64 encoded password

### DIFF
--- a/utils/set-jahia-root-password.yml
+++ b/utils/set-jahia-root-password.yml
@@ -11,13 +11,13 @@ globals:
 
 onInstall:
   - cmd [proc]: |-
-        echo ${globals.new_password} > $DATA_PATH/digital-factory-data/root.pwd
+        base64 -d <<< "${globals.new_password}" > $DATA_PATH/digital-factory-data/root.pwd
         chown tomcat:tomcat $DATA_PATH/digital-factory-data/root.pwd
 
 settings:
   fields:
     - name: rootpwd
       type: string
-      caption: New Jahia root password
+      caption: New Jahia root password encoded in base64
       vtype: string
       required: true


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-379

Short description:
the package now expect a base64 encoded password