### PR TITLE
Paas 437 clean db params

### DIFF
--- a/dx-cluster-universal.yml
+++ b/dx-cluster-universal.yml
@@ -528,8 +528,6 @@ settings:
       default: mariadb-dockerized
       required: true
       values:
-        - value: mysql
-          caption: MySQL CE
         - value: mariadb-dockerized
           caption: MariaDB
 
@@ -539,16 +537,6 @@ settings:
       required: true
       dependsOn:
         stack:
-          mysql:
-            - value: slave
-              caption: Master-Slave with extra slaves
-            - value: master
-              caption: Master-Master with extra slaves
-            - value: single
-              caption: Single Group Replication
-            - value: multi
-              caption: Multi Group Replication
-
           mariadb-dockerized:
             - value: single
               caption: One, lonely, sad and single master
@@ -565,8 +553,6 @@ settings:
       name: dbnodeType
       dependsOn:
         stack:
-          mysql:
-            - value: mysql
           mariadb-dockerized:
             - value: mariadb-dockerized
 
@@ -576,16 +562,12 @@ settings:
       name: dbnodes
       dependsOn:
         dbscheme:
-          lonely:
+          single:
             - value: 1
           slave:
             - value: 2
           master:
             - value: 2
-          single:
-            - value: 1
-          multi:
-            - value: 3
           galera:
             - value: 3
 

--- a/dx-cluster-universal.yml
+++ b/dx-cluster-universal.yml
@@ -294,7 +294,7 @@ actions:
         mysql -e "GRANT PROCESS ON *.* TO 'datadog'@'localhost';"
         mysql -e "GRANT SELECT ON performance_schema.* TO 'datadog'@'localhost';"
       user: root
-    - if ( settings.is_proxysql == 'true' ):
+    - if ( globals.is_proxysql == 'true' ):
         - log: "## Create Datadog database use on proxys"
         - cmd[proxy]: |-
             mysql -e "CREATE USER 'datadog'@'localhost' IDENTIFIED BY '${DB_USER_DATADOG}';"


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-437

Short description:
- Use only is_proxysql global value (setting has been removed)
- Remove mysql from DB stacks options