### PR TITLE
PAAS-342: set 64 cloudlets for dx and db nodes if prod env

### DIFF
--- a/dx-cluster-universal.yml
+++ b/dx-cluster-universal.yml
@@ -149,6 +149,12 @@ onUninstall:
     user: root
 
 onInstall:
+  - if ( '${globals.operating_mode}' == "production" ):
+      - log: "Update cloudlets for prod environment"
+      - api[proc, cp, sqldb]: environment.control.SetCloudletsCountByGroup
+        count: 1
+        flexibleCloudlets: 64
+        fixedCloudlets: 1
   - log: "## Beginning installation of DX"
   # - if (/\/raw\/[0-9]+\.[0-9]+\.prod$/.test(baseUrl)):
   - if (/\/raw\/v[0-9]+(\.[0-9]+)+$/.test(baseUrl)):


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-342

Short description:
set cloudlets to 64 for dx and db nodes if the env is in production mode