### PR TITLE
Paas 687 Special characters in password can break Jahia env creation

### DIFF
--- a/jahia/jahia_actions.yml
+++ b/jahia/jahia_actions.yml
@@ -73,7 +73,7 @@ actions:
 
     - copyApp: proc, cp
     - cmd[proc]: |-
-        echo "${settings.rootpwd}" > $DATA_PATH/digital-factory-data/root.pwd
+        base64 -d <<< "${settings.rootpwd.toBase64()}" > $DATA_PATH/digital-factory-data/root.pwd
       user: tomcat
     - defineToolsPwd
     - setToolsPwd: proc, cp
@@ -118,8 +118,13 @@ actions:
   defineToolsPwd:
     - log: "## Now setting tools password"
     - cmd[proc]: |-
-        cd /opt/tomcat/webapps/ROOT/WEB-INF/lib/
-        /usr/java/latest/bin/jjs -cp $(find . -name jahia-commons-*.jar):$(find . -name jasypt-*.jar) -scripting <<< "print(org.jahia.commons.encryption.EncryptionUtils.pbkdf2Digest(\"${settings.toolspwd}\", \"p\"))" | egrep '^(p|s2):[[:graph:]]+=$'
+        if [ ! -f /usr/local/bin/reset-jahia-tools-manager-password.py ]; then
+          wget -O /usr/local/bin/reset-jahia-tools-manager-password.py ${baseUrl}/scripts/reset-jahia-tools-manager-password.py
+          chmod u+x /usr/local/bin/reset-jahia-tools-manager-password.py
+        fi
+        /usr/local/bin/reset-jahia-tools-manager-password.py "${settings.toolspwd.toBase64()}" $STACK_PATH/conf/digital-factory-config/jahia/jahia.properties
+        awk '$1=="jahiaToolManagerPassword" {print $NF}' $STACK_PATH/conf/digital-factory-config/jahia/jahia.properties
+      user: root
     - setGlobals:
         toolspwd: ${response.out}
     - api[proc, cp]: env.control.AddContainerEnvVars

--- a/scripts/reset-jahia-tools-manager-password.py
+++ b/scripts/reset-jahia-tools-manager-password.py
@@ -18,6 +18,6 @@ new_salt = b2a_base64(salt, newline=False).decode("utf-8")
 
 with fileinput.FileInput(file_path, inplace=True, backup='.bak') as file:
     for line in file:
-        if line.startswith('jahiaToolManagerPassword ='):
+        if line.startswith('jahiaToolManagerPassword'):
             line = "jahiaToolManagerPassword = p:" + new_salt + "$" + new_password_hash + "\n"
         print(line, end='')

--- a/utils/set-jahia-tools-password.yml
+++ b/utils/set-jahia-tools-password.yml
@@ -20,9 +20,11 @@ onInstall:
 
   - cmd [cp,proc]: |-
         yum -y install python3
-        wget -O /usr/local/bin/reset-jahia-tools-manager-password.py ${globals.universal_url}/scripts/reset-jahia-tools-manager-password.py
-        chmod u+x /usr/local/bin/reset-jahia-tools-manager-password.py
-        reset-jahia-tools-manager-password.py "${globals.new_password}" $STACK_PATH/conf/digital-factory-config/jahia/jahia.properties
+        if [ ! -f /usr/local/bin/reset-jahia-tools-manager-password.py ]; then
+          wget -O /usr/local/bin/reset-jahia-tools-manager-password.py ${globals.universal_url}/scripts/reset-jahia-tools-manager-password.py
+          chmod u+x /usr/local/bin/reset-jahia-tools-manager-password.py
+        fi
+        /usr/local/bin/reset-jahia-tools-manager-password.py "${globals.new_password}" $STACK_PATH/conf/digital-factory-config/jahia/jahia.properties
         awk '$1=="jahiaToolManagerPassword" {print $NF}' /opt/tomcat/conf/digital-factory-config/jahia/jahia.properties
     user: root
   - api[proc, cp]: env.control.AddContainerEnvVars


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-687
Short description:
super user password should now be special character proof
tools password too, I drop jjs for use reset-jahia-tools-manager-password.py instead (and add to fix a little thing on it)