### PR TITLE
Paas 687 Special characters in password can break Jahia env creation

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -18,7 +18,6 @@ globals:
   db_user_datadog: ${fn.password(20)}
   redis_pass: ${fn.password(20)}
   mngr_user: manager
-  mngr_pass: ${settings.toolspwd}
   dx_version: ${settings.productVersion}
   package_type: dev
   operating_mode: ${settings.mode}

--- a/text/success.md
+++ b/text/success.md
@@ -5,7 +5,7 @@
 
 ### Manager User 
 - Login: ${globals.mngr_user}
-- Password: ${globals.mngr_pass}
+- Password: ${settings.toolspwd}
 - [${env.protocol}://${env.domain}/tools/](${env.protocol}://${env.domain}/tools/) 
 
 ### DB User 

--- a/utils/set-jahia-tools-password.yml
+++ b/utils/set-jahia-tools-password.yml
@@ -20,6 +20,7 @@ onInstall:
 
   - cmd [cp,proc]: |-
         yum -y install python3
+  - cmd [cp,proc]: |-
         if [ ! -f /usr/local/bin/reset-jahia-tools-manager-password.py ]; then
           wget -O /usr/local/bin/reset-jahia-tools-manager-password.py ${globals.universal_url}/scripts/reset-jahia-tools-manager-password.py
           chmod u+x /usr/local/bin/reset-jahia-tools-manager-password.py


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-687

Short description:
- split python install in another cmd in order to not spoil hash response output
- remove globals.mnfr_pass in order to fix strange behavior with some specials chars