### PR TITLE
PAAS-1170: Use vault to fetch haproxy configurations - fix

### DIFF
--- a/utils/rewrite-rules.yml
+++ b/utils/rewrite-rules.yml
@@ -25,10 +25,22 @@ actions:
         source /.jelenv
         VAULT_TOKEN=$(curl -s -XPOST $VAULT_CLUSTER_URL/v1/auth/approle/login --data '{"role_id": "'$VAULT_ROLE_ID'", "secret_id": "'$VAULT_SECRET_ID'"}' | jq -r .auth.client_token)
         VAULT_SECRET_PATH="${settings.vault_secret_path}"
+      user: root
+    - cmd [bl]: |-
         curl -s -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_CLUSTER_URL/v1/kv/data/$VAULT_SECRET_PATH | jq -r .data.data[] > "${globals.rewrite_rules_file}"
         sed -i -ne '/## START_REWRITES ##/{p;r ${globals.rewrite_rules_file}' -e ':a;n;/## END_REWRITES ##/{p;b};ba};p' "${globals.haproxy_frontend_file}"
         rm "${globals.rewrite_rules_file}"
       user: root
+    - if ("${response.errOut}" != ""):
+        - set:
+            error-out: "${response.errOut}"
+        - cmd [bl]: |-
+            rm "${globals.haproxy_backup_file}"
+          user: root
+        - log: "Get Rewrite Rules Failed"
+        - return:
+            type: error
+            message: "${this.error-out}"
 
   reloadHAProxy:
     - cmd [bl]: |-


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1170

Short description:
Check for jq command fail added