### PR TITLE
PAAS-1457: update events before any other action in v3 migration script

### DIFF
--- a/migrations/v3/migration-to-v3.yml
+++ b/migrations/v3/migration-to-v3.yml
@@ -24,6 +24,7 @@ onInstall:
   - checkHaproxyHealth: bl
   - checkMariadbHealth: sqldb
   - checkGaleraClusterHealth: sqldb
+  - eventsUpdate
   ### End Pre-checks
 
   - addHealthcheckEnvVar # PAAS-1369
@@ -37,7 +38,6 @@ onInstall:
   - increaseHaproxyTimeout # PAAS-1433
 
   ### Post-actions
-  - eventsUpdate # PAAS-1322
   - setEnvVersion: ${globals.version}
   - logEvent:
       target: ${nodes.proc.first.id}


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1457

Short description:
We noticed with Amit that the events update should be done before Tomcat redeploy (otherwise it would have been really useless to remove "redeploy.conf" actions from onBeforeRedeploy events), and generally speaking, events update should always be done before