### PR TITLE
PAAS-1492: add Haproxy status check & custom check for on-call monitor

### DIFF
--- a/configs/dd_agent_haproxy_conf.yml
+++ b/configs/dd_agent_haproxy_conf.yml
@@ -17,3 +17,6 @@ instances:
     username: admin
     password: my_awesome_password
     collect_status_metrics: true
+    enable_service_check: true
+    status_check: true
+

--- a/haproxy/haproxy_actions.yml
+++ b/haproxy/haproxy_actions.yml
@@ -98,6 +98,9 @@ actions:
         echo " - provide:${_PROVIDE}" >> /etc/datadog-agent/datadog.yaml
         echo " - role:${_ROLE}" >> /etc/datadog-agent/datadog.yaml
         echo " - envmode:${jahia_cfg_operatingMode}" >> /etc/datadog-agent/datadog.yaml
+        wget -qO /etc/datadog-agent/checks.d/haproxy_one_remaining_browsing.py ${baseUrl}/scripts/haproxy_one_remaining_browsing.py
+        chown dd-agent:dd-agent /etc/datadog-agent/checks.d/haproxy_one_remaining_browsing.py
+        ln -s /etc/datadog-agent/conf.d/haproxy.d/conf.yaml /etc/datadog-agent/conf.d/haproxy_one_remaining_browsing.yaml
         wget -qO /etc/datadog-agent/conf.d/haproxy.d/conf.yaml ${baseUrl}/configs/dd_agent_haproxy_conf.yml
         mkdir /etc/datadog-agent/conf.d/jelastic.d /var/log/jelastic-packages
         chown haproxy:root /var/log/jelastic-packages

--- a/migrations/v4/migration-to-v4.yml
+++ b/migrations/v4/migration-to-v4.yml
@@ -30,6 +30,7 @@ onInstall:
 
   - updatHaproxyHealthcheck                            # PAAS-1345
   - updateDatadogProcessCheck                          # PAAS-1465
+  - fixHaproxyBackendMonitors                          # PAAS-1492
   - gotJexperience                                     # PAAS-1458 test if jexperience module is present
   - if("${globals.gotJexperienceBundleInfo}" != ""):   # if present then
       - gotJexperienceVersion                          #     get is version
@@ -88,6 +89,18 @@ actions:
         exit 0
     - setGlobals:
         gotJexperienceBundleInfo: ${response.out}
+
+  fixHaproxyBackendMonitors:
+    cmd[bl]: |-
+      if ! grep -qE "enable_service_check" /etc/datadog-agent/conf.d/haproxy.d/conf.yaml; then
+        wget -qO /etc/datadog-agent/checks.d/haproxy_one_remaining_browsing.py ${baseUrl}/../../scripts/haproxy_one_remaining_browsing.py
+        chown dd-agent:dd-agent /etc/datadog-agent/checks.d/haproxy_one_remaining_browsing.py
+        ln -s /etc/datadog-agent/conf.d/haproxy.d/conf.yaml /etc/datadog-agent/conf.d/haproxy_one_remaining_browsing.yaml
+        echo "    enable_service_check: true" >> /etc/datadog-agent/conf.d/haproxy.d/conf.yaml
+        echo "    status_check: true" >> /etc/datadog-agent/conf.d/haproxy.d/conf.yaml
+        systemctl restart datadog-agent
+      fi
+    user: root
 
   gotJexperienceVersion:
     - cmd[proc]: |-

--- a/scripts/haproxy_one_remaining_browsing.py
+++ b/scripts/haproxy_one_remaining_browsing.py
@@ -1,0 +1,49 @@
+from os import system
+import requests
+import re
+
+# the following try/except block will make the custom check compatible with any Agent version
+try:
+    # first, try to import the base class from old versions of the Agent...
+    from checks import AgentCheck
+except ImportError:
+    # ...if the above failed, the check is running in Agent version 6 or later
+    from datadog_checks.base import AgentCheck
+
+__version__ = "1.0.0"
+
+
+class CheckNumberBrowsingRemaining(AgentCheck):
+    __NAMESPACE__ = "haproxy"
+    SERVICE_CHECK_NAME = "number_browsing_remaining"
+    HAPROXY_CONF_FILE = '/etc/haproxy/haproxy.cfg.d/00-global.cfg'
+    BROWSING_BACKEND_NAME = 'bk_jahia'
+
+    def check(self, instance):
+        try:
+            res = requests.get('http://localhost:80/haproxy_adm_panel;csv;norefresh',
+                               auth=(instance["username"], instance["password"]))
+            haproxy_stats = res.text.splitlines()
+            # With this regexp, we only keep individual backend lines, not the global BACKEND one
+            r_backend = re.compile('^' + self.BROWSING_BACKEND_NAME + ',(?!BACKEND).*')
+            r_backend_up = re.compile('.*,UP,.*')
+            backend_stats = filter(r_backend.match, haproxy_stats)
+            backend_up_stats = filter(r_backend_up.match, backend_stats)
+            if len(backend_up_stats) <= 1:
+                if len(backend_stats) != len(backend_up_stats):
+                    self.service_check(
+                        self.SERVICE_CHECK_NAME,
+                        AgentCheck.CRITICAL,
+                        message='Not enough Browsing nodes are running.'
+                    )
+                    return
+            self.service_check(
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.OK,
+                message='Enough browsing nodes are running.'
+            )
+            return
+        except Exception:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL)
+            self.log.exception("Can't get Haproxy stats.")
+            raise


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1492

Short description:
* Enable the status check to fix "Haproxy no backend" and "Haproxy backend down"
* Add custom check for the on-call monitor to raise an alert if there's only one (or zero) browsing node UP (unless the environment contains only one browsing node)

Related to https://github.com/Jahia/paas-monitoring/pull/127